### PR TITLE
fix: replace deprecated model

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Gen-AI Twitter Generator
 
-**Gen-AI Twitter Generator** is an intuitive tool designed to craft engaging, professional, and trend-aligned Twitter posts effortlessly. Leveraging advanced natural language generation, this app is built on cutting-edge AI models, including **Llama-3.2-90B-text-preview**, a state-of-the-art large language model known for its fluency, contextual understanding, and semantic relevance. It allows users to customize their posts based on topics, length, language, and hashtags, ensuring precise alignment with their audience and content strategy.  
+**Gen-AI Twitter Generator** is an intuitive tool designed to craft engaging, professional, and trend-aligned Twitter posts effortlessly. Leveraging advanced natural language generation, this app is built on cutting-edge AI models, including **Llama-3.2-90B-vision-preview**, a state-of-the-art large language model known for its fluency, contextual understanding, and semantic relevance. It allows users to customize their posts based on topics, length, language, and hashtags, ensuring precise alignment with their audience and content strategy.  
 
 ## 🌟 Features
 - **Customizable Posts**: Select topics, desired length (Short, Medium, Long), and language (English, Hinglish).

--- a/llm_add.py
+++ b/llm_add.py
@@ -3,7 +3,7 @@ import os
 from dotenv import load_dotenv
 
 load_dotenv()
-llm = ChatGroq(groq_api_key=os.getenv("GROQ_API_KEY"), model_name="llama-3.2-90b-text-preview")
+llm = ChatGroq(groq_api_key=os.getenv("GROQ_API_KEY"), model_name="llama-3.2-90b-vision-preview")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hello,

Thanks for building with Groq! We recently deprecated the `llama-3.2-90B-text-preview `model after notifying developers over email in favor of the full vision model `llama-3.2-90b-vision-preview`. If you have a text-only workload, you can also change to `llama-3.1-70b-versatile`. 

See more information here: [Documentation](https://console.groq.com/docs/deprecations).

I changed the model name for you in the code. Let me know if you have any questions! This looks like a cool project.

BK at Groq